### PR TITLE
fix(workflow): commitlint throw error on pull/merge max-line length

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'body-max-length': [0]
+    'body-max-length': [0],
+    'body-max-line-length': [0]
   }
   // rules: {
   //   "type-enum": [2, "always", ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test", "button"]],


### PR DESCRIPTION
Disabled body and line max commit length, throwing error on release build.